### PR TITLE
Fixes #27 syntax errors (with some gotchas)

### DIFF
--- a/src/zcl_abapgit_res_repo_info_ext.clas.abap
+++ b/src/zcl_abapgit_res_repo_info_ext.clas.abap
@@ -82,8 +82,17 @@ CLASS zcl_abapgit_res_repo_info_ext IMPLEMENTATION.
                                                        iv_password = ls_request_data-password ).
         ENDIF.
 
+        " Marcello Urbani: removed call due to syntax error.
+        " Planned to use a dynamic call but don't know the signature
+        " TODO: actually find out
         "Check whether passed repo URL has public or privated access
-        ls_response_data-access_mode = zcl_abapgit_http=>determine_access_level( ls_request_data-url ).
+        "ls_response_data-access_mode = zcl_abapgit_http=>determine_access_level( ls_request_data-url ).
+        IF  ls_request_data-user         IS NOT INITIAL AND
+            ls_request_data-password     IS NOT INITIAL.
+          ls_response_data-access_mode = 'PRIVATE'.
+        ELSE.
+          ls_response_data-access_mode = 'PUBLIC'.
+        ENDIF.
 
         "Retrieve list of branches for repo
         IF  ls_response_data-access_mode = 'PUBLIC'  OR

--- a/src/zcl_abapgit_res_repo_info_ext.clas.testclasses.abap
+++ b/src/zcl_abapgit_res_repo_info_ext.clas.testclasses.abap
@@ -142,7 +142,7 @@ CLASS ltcl_simple_transformation IMPLEMENTATION.
     <lt_result>-name = zcl_abapgit_res_repo_info_ext=>co_root_name_request.
     GET REFERENCE OF ls_data INTO <lt_result>-value.
 
-    CALL TRANSFORMATION abapgit_st_repo_info_ext_req
+    CALL TRANSFORMATION zabapgit_st_repo_info_ext_req
       SOURCE XML lv_input_xml
       RESULT     (lt_result).
 

--- a/src/zcl_abapgit_res_repo_pull.clas.abap
+++ b/src/zcl_abapgit_res_repo_pull.clas.abap
@@ -43,7 +43,7 @@ CLASS zcl_abapgit_res_repo_pull DEFINITION
   PROTECTED SECTION.
   PRIVATE SECTION.
 
-    DATA mo_application_log TYPE REF TO if_a4c_logger .
+    " DATA mo_application_log TYPE REF TO if_a4c_logger .
 
     METHODS validate_request_data
       IMPORTING
@@ -67,6 +67,9 @@ CLASS zcl_abapgit_res_repo_pull IMPLEMENTATION.
       lo_job_action    TYPE REF TO if_cbo_job_action.
 
     TRY.
+        " TODO: implement with valilla ABAPGIT
+        ZCX_ABAPGIT_EXCEPTION=>raise( 'Pull is not yet implemented' ).
+
 *------ Get Repository Key
         request->get_uri_attribute( EXPORTING name = 'key' mandatory = abap_true
                                     IMPORTING value = lv_repo_key ).
@@ -79,7 +82,7 @@ CLASS zcl_abapgit_res_repo_pull IMPLEMENTATION.
                                   root_name    = co_root_name_pull
                                   content_type = co_content_type_repo_v1 ) ).
 
-        zcl_abapgit_operation_log=>clear( ).
+        " zcl_abapgit_operation_log=>clear( ).
 
 *------ Retrieve request data
         request->get_body_data(
@@ -165,11 +168,11 @@ CLASS zcl_abapgit_res_repo_pull IMPLEMENTATION.
           content_type = co_content_type_object_v1 ).
 
 *------ prepare response information
-        DATA(lt_result_table) = zcl_abapgit_operation_log=>get_result_table( ).
+        " DATA(lt_result_table) = zcl_abapgit_operation_log=>get_result_table( ).
 
-        response->set_body_data(
-          content_handler = lo_resp_content_handler
-          data            = lt_result_table ).
+        " response->set_body_data(
+        "   content_handler = lo_resp_content_handler
+        "   data            = lt_result_table ).
 *OLD end
 
 *NEW start
@@ -177,9 +180,10 @@ CLASS zcl_abapgit_res_repo_pull IMPLEMENTATION.
 *NEW end
 
 *---- Handle issues
-      CATCH zcx_abapgit_exception zcx_abapgit_app_log cx_cbo_job_scheduler cx_uuid_error INTO DATA(lx_exception).
+*      CATCH zcx_abapgit_exception zcx_abapgit_app_log cx_cbo_job_scheduler cx_uuid_error INTO DATA(lx_exception).
+      CATCH zcx_abapgit_exception cx_cbo_job_scheduler cx_uuid_error INTO DATA(lx_exception).
         ROLLBACK WORK.
-        cx_adt_rest_abapgit=>raise_with_error(
+        zcx_adt_rest_abapgit=>raise_with_error(
             ix_error       = lx_exception
             iv_http_status = cl_rest_status_code=>gc_server_error_internal ).
     ENDTRY.

--- a/src/zcl_abapgit_res_repo_pull.clas.testclasses.abap
+++ b/src/zcl_abapgit_res_repo_pull.clas.testclasses.abap
@@ -40,7 +40,7 @@ CLASS ltcl_simple_transformation IMPLEMENTATION.
     <lt_result>-name = zcl_abapgit_res_repo_pull=>co_root_name_pull.
     GET REFERENCE OF ls_data INTO <lt_result>-value.
 
-    CALL TRANSFORMATION abapgit_st_repo_pull
+    CALL TRANSFORMATION zabapgit_st_repo_pull
       SOURCE XML lv_input_xml
       RESULT     (lt_result).
 
@@ -76,7 +76,7 @@ CLASS ltcl_simple_transformation IMPLEMENTATION.
     <lt_result>-name = zcl_abapgit_res_repo_pull=>co_root_name_pull.
     GET REFERENCE OF ls_data INTO <lt_result>-value.
 
-    CALL TRANSFORMATION abapgit_st_repo_pull
+    CALL TRANSFORMATION zabapgit_st_repo_pull
       SOURCE XML lv_input_xml
       RESULT     (lt_result).
 
@@ -113,7 +113,7 @@ CLASS ltcl_simple_transformation IMPLEMENTATION.
     <lt_result>-name = zcl_abapgit_res_repo_pull=>co_root_name_pull.
     GET REFERENCE OF ls_data INTO <lt_result>-value.
 
-    CALL TRANSFORMATION abapgit_st_repo_pull
+    CALL TRANSFORMATION zabapgit_st_repo_pull
       SOURCE XML lv_input_xml
       RESULT     (lt_result).
 
@@ -149,7 +149,7 @@ CLASS ltcl_simple_transformation IMPLEMENTATION.
     <lt_result>-name = zcl_abapgit_res_repo_pull=>co_root_name_pull.
     GET REFERENCE OF ls_data INTO <lt_result>-value.
 
-    CALL TRANSFORMATION abapgit_st_repo_pull
+    CALL TRANSFORMATION zabapgit_st_repo_pull
       SOURCE XML lv_input_xml
       RESULT     (lt_result).
 

--- a/src/zcl_abapgit_res_repos.clas.abap
+++ b/src/zcl_abapgit_res_repos.clas.abap
@@ -166,7 +166,7 @@ CLASS zcl_abapgit_res_repos IMPLEMENTATION.
 
   METHOD validate_request_data.
 
-    DATA: tr_check_required TYPE abap_boolean VALUE abap_true.
+    DATA: tr_check_required TYPE abap_bool VALUE abap_true.
 
     "check whether git url is well formed
     zcl_abapgit_url=>validate( |{ is_request_data-url }| ).

--- a/src/zcl_abapgit_res_repos.clas.locals_def.abap
+++ b/src/zcl_abapgit_res_repos.clas.locals_def.abap
@@ -6,7 +6,7 @@ INTERFACE lif_abapgit_provider.
     validate_package IMPORTING iv_package TYPE devclass
                      RAISING   zcx_abapgit_exception,
     is_tr_check_required IMPORTING iv_package TYPE devclass
-                         RETURNING VALUE(rv_is_required) TYPE abap_boolean
+                         RETURNING VALUE(rv_is_required) TYPE abap_bool
                          RAISING   zcx_abapgit_exception,
     list_repositories RETURNING VALUE(rt_list) TYPE zif_abapgit_definitions=>ty_repo_ref_tt
                       RAISING   zcx_abapgit_exception,


### PR DESCRIPTION
This is NOT a proper fix:

- zcl_abapgit_res_repo_pull->post just raises an exception
- zcl_abapgit_res_repo_info_ext->post just assumes the repo is private if an user and password is passed

On the plus side all trivial errors (abap_boolean, cl_whatever => zcl_whatever) are fixed it does activate without errors

To fix properly would really help to have access to the version of abapgit this is based upon. Do you know where I can find it?