### PR TITLE
add z namespace

### DIFF
--- a/src/zcl_abapgit_res_repo_info_ext.clas.abap
+++ b/src/zcl_abapgit_res_repo_info_ext.clas.abap
@@ -23,8 +23,8 @@ CLASS zcl_abapgit_res_repo_info_ext DEFINITION
     CONSTANTS co_content_type_response_v1 TYPE string
       VALUE 'application/abapgit.adt.repo.info.ext.response.v1+xml' ##NO_TEXT.
     CONSTANTS co_root_name_request        TYPE string VALUE 'REPOSITORY_EXTERNAL_REQ' ##NO_TEXT.
-    CONSTANTS co_st_name_request          TYPE string VALUE 'ABAPGIT_ST_REPO_INFO_EXT_REQ' ##NO_TEXT.
-    CONSTANTS co_st_name_response         TYPE string VALUE 'ABAPGIT_ST_REPO_INFO_EXT_RES' ##NO_TEXT.
+    CONSTANTS co_st_name_request          TYPE string VALUE 'ZABAPGIT_ST_REPO_INFO_EXT_REQ' ##NO_TEXT.
+    CONSTANTS co_st_name_response         TYPE string VALUE 'ZABAPGIT_ST_REPO_INFO_EXT_RES' ##NO_TEXT.
     CONSTANTS co_root_name_response       TYPE string VALUE 'REPOSITORY_EXTERNAL' ##NO_TEXT.
 
     METHODS post REDEFINITION.

--- a/src/zcl_abapgit_res_repo_pull.clas.abap
+++ b/src/zcl_abapgit_res_repo_pull.clas.abap
@@ -25,16 +25,16 @@ CLASS zcl_abapgit_res_repo_pull DEFINITION
     TYPES:
       tt_repo_w_links TYPE STANDARD TABLE OF ty_repo_w_links WITH DEFAULT KEY.
 
-    CONSTANTS co_class_name             TYPE seoclsname VALUE 'CL_ABAPGIT_RES_REPOS' ##NO_TEXT.
-    CONSTANTS co_resource_type TYPE string     VALUE 'REPOS' ##NO_TEXT.             "EC NOTEXT
-    CONSTANTS co_st_name_pull           TYPE string     VALUE 'ABAPGIT_ST_REPO_PULL' ##NO_TEXT.
-    CONSTANTS co_st_name_post_res       TYPE string     VALUE 'ABAPGIT_ST_REPO_POST_RES'.
+    CONSTANTS co_class_name             TYPE seoclsname VALUE 'ZCL_ABAPGIT_RES_REPOS' ##NO_TEXT.
+    CONSTANTS co_resource_type          TYPE string     VALUE 'REPOS' ##NO_TEXT.             "EC NOTEXT
+    CONSTANTS co_st_name_pull           TYPE string     VALUE 'ZABAPGIT_ST_REPO_PULL' ##NO_TEXT.
+    CONSTANTS co_st_name_post_res       TYPE string     VALUE 'ZABAPGIT_ST_REPO_POST_RES'.
     CONSTANTS co_root_name_pull         TYPE string     VALUE 'REPOSITORY' ##NO_TEXT.
     CONSTANTS co_root_name_post_res     TYPE string     VALUE 'OBJECTS'.
     CONSTANTS co_content_type_repo_v1   TYPE string     VALUE 'application/abapgit.adt.repo.v1+xml' ##NO_TEXT.
     CONSTANTS co_content_type_repos_v1  TYPE string     VALUE 'application/abapgit.adt.repos.v1+xml' ##NO_TEXT.
     CONSTANTS co_content_type_object_v1 TYPE string     VALUE 'application/abapgit.adt.repo.object.v1+xml' ##NO_TEXT.
-    CONSTANTS co_st_name_get            TYPE string     VALUE 'ABAPGIT_ST_REPOS' ##NO_TEXT.
+    CONSTANTS co_st_name_get            TYPE string     VALUE 'ZABAPGIT_ST_REPOS' ##NO_TEXT.
     CONSTANTS co_root_name_get          TYPE string     VALUE 'REPOSITORIES' ##NO_TEXT.
     CONSTANTS co_content_type_repo_v2   TYPE string     VALUE 'application/abapgit.adt.repo.v2+xml' ##NO_TEXT.
 


### PR DESCRIPTION
closes #30 

during the transformation from `SAP` namespace to `Z` namespace somehow the constants are ignored.