### PR TITLE
Fixes #27 syntax error (regressed)

### DIFF
--- a/src/zcl_abapgit_res_repos.clas.abap
+++ b/src/zcl_abapgit_res_repos.clas.abap
@@ -168,7 +168,7 @@ CLASS zcl_abapgit_res_repos IMPLEMENTATION.
 
   METHOD validate_request_data.
 
-    DATA: lv_tr_check_required TYPE abap_boolean VALUE abap_true.
+    DATA: lv_tr_check_required TYPE abap_bool VALUE abap_true.
 
     "check whether git url is well formed
     zcl_abapgit_url=>validate( |{ is_request_data-url }| ).
@@ -235,9 +235,10 @@ CLASS zcl_abapgit_res_repos IMPLEMENTATION.
 
     DATA: lt_request_data TYPE tt_request_data.
 
-    DATA(lo_adt_content_handler) = cl_adt_rest_cnt_hdl_factory=>get_instance( )->get_handler_for_xml_using_st( st_name      = co_st_name_post_v2
-                                                                                                            root_name    = co_root_name_post_v2
-                                                                                                            content_type = co_content_type_repo_v2 ).
+    DATA(lo_adt_content_handler) = cl_adt_rest_cnt_hdl_factory=>get_instance( )->get_handler_for_xml_using_st(
+      st_name      = co_st_name_post_v2
+      root_name    = co_root_name_post_v2
+      content_type = co_content_type_repo_v2 ).
     DATA(lo_request_content_handler) = cl_adt_rest_comp_cnt_handler=>create( request         = iv_request
                                                                              content_handler = lo_adt_content_handler ).
 

--- a/src/zcl_abapgit_res_repos.clas.locals_def.abap
+++ b/src/zcl_abapgit_res_repos.clas.locals_def.abap
@@ -6,7 +6,7 @@ INTERFACE lif_abapgit_provider.
     validate_package IMPORTING iv_package TYPE devclass
                      RAISING   zcx_abapgit_exception,
     is_tr_check_required IMPORTING iv_package TYPE devclass
-                         RETURNING VALUE(rv_is_required) TYPE abap_boolean
+                         RETURNING VALUE(rv_is_required) TYPE abap_bool
                          RAISING   zcx_abapgit_exception,
     list_repositories RETURNING VALUE(rt_list) TYPE zif_abapgit_definitions=>ty_repo_ref_tt
                       RAISING   zcx_abapgit_exception,


### PR DESCRIPTION
a couple of syntax errors were reincluded in aec0fdf65bef4b9ba6bafb0c13141103d67c05c3

as of basis 7.52 abap_boolean doesn't exist, which causes dumps.

![image](https://user-images.githubusercontent.com/2453277/66607550-643afb00-ebac-11e9-8645-c450601eceec.png)

Fixed this, abapgit repositories do show up in eclipse. Pull doesn't work yet