### PR TITLE
removed old parameter to fix syntax error

### DIFF
--- a/src/zcl_abapgit_http_adt.clas.abap
+++ b/src/zcl_abapgit_http_adt.clas.abap
@@ -91,8 +91,7 @@ CLASS zcl_abapgit_http_adt IMPLEMENTATION.
     " Disable internal auth dialog (due to its unclarity)
     li_client->propertytype_logon_popup = if_http_client=>co_disabled.
 
-    zcl_abapgit_login_manager=>load( iv_uri    = iv_url
-                                     ii_client = li_client ).
+    zcl_abapgit_login_manager=>load( iv_url ).
 
     zcl_abapgit_exit=>get_instance( )->http_client( ii_client = li_client iv_url = iv_url ).
 


### PR DESCRIPTION
didn't upgrade my agbapgit in a while, when I did this broke for a small syntax error.
Once fixed works well enough to create this branch and commit with the plugin.

I see this is now deprecated. Is the plan to move to [odense_z](https://github.com/abapGit/odense-z)?
Or just lack of time to maintain? In th elatter case I guess I can pick this up
